### PR TITLE
Add title/script blocks and sticky footer to base template

### DIFF
--- a/healthyplanet/templates/base.html
+++ b/healthyplanet/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="h-100">
 
 <head>
     <meta charset="UTF-8">
@@ -24,10 +24,10 @@
         integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous">
         </script>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" type="text/css">
-    <title></title>
+    <title>{% block title %}{% endblock %}</title>
 </head>
 
-<body>
+<body class="d-flex flex-column h-100">
     <header>
         <nav class="navbar navbar-expand-lg bg-main">
             <div class="container-fluid">
@@ -66,8 +66,8 @@
         {% endblock %}
     </main>
     <!-- Footer -->
-    <footer>
-        <div class="container-fluid gx-0 pb-3">
+    <footer class="mt-auto">
+        <div class="container-fluid pb-3">
             <div class="row pt-2">
                 <div class="col-lg-8 col-md-10 mx-auto">
                     <ul class="list-inline text-center">
@@ -104,6 +104,8 @@
     </footer>
     <script src="{{url_for('static', filename='js/script.js')}}"></script>
     <script>$('#copyright').text(new Date().getFullYear());</script>
+    {% block scripts %}
+    {% endblock %}
 </body>
 
 </html>


### PR DESCRIPTION
Added 'title' and 'script' content blocks to the base template, so we can add page titles and custom js to individual pages. 

Set up the footer to stick to the bottom of the page and removed a class from the footer that was causing a display bug.